### PR TITLE
 fix typo in constructor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ function SDK(options = {}) {
   }
 
   if (options.project) {
-    project = options.token;
+    project = options.project;
   }
 
   if (options.localExp) {


### PR DESCRIPTION
use options.project for "project" initialization