### PR TITLE
fix FilterOperator error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ debug
 # misc
 .DS_Store
 .vscode
+.idea
 
 # unneeded compiled files
 dist/*.html

--- a/src/schemes/http/Query.ts
+++ b/src/schemes/http/Query.ts
@@ -11,7 +11,7 @@ interface IQueryParameters {
   sort: string | string[];
   status: string | string[];
   filter: {
-    [field: string]: { [operator in FilterOperator]: any };
+    [field: string]: { [operator in FilterOperator]?: any };
   };
   lang: object; // TODO: fix type
   q: string;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] API docs have been updated (by executing `npm run documentation`)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?

Sorry I have not create an issue before that. 
When I use `filter`, I can't use only one `filterOperator` e.g. `eq` or `in` because operator is a FilterOperator and we need to have all operator in filters.

![image](https://user-images.githubusercontent.com/17801784/69152962-ab86a680-0add-11ea-8d0f-65da98a54587.png)

![image](https://user-images.githubusercontent.com/17801784/69152930-9873d680-0add-11ea-8597-343a12ba2e29.png)



## What is the new behavior?

We can now use only one operator.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

I don't know if it's the good way to correct that, I wait your review 😉 