### PR TITLE
Set lang type to 'string'

### DIFF
--- a/src/schemes/http/Query.ts
+++ b/src/schemes/http/Query.ts
@@ -13,7 +13,7 @@ interface IQueryParameters {
   filter: {
     [field: string]: { [operator in FilterOperator]?: any };
   };
-  lang: object; // TODO: fix type
+  lang: string;
   q: string;
   groups: string | string[];
   activity_skip: number;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] API docs have been updated (by executing `npm run documentation`)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
Lang doesn't have a good type for the query : `lang: object; // TODO: fix type`
I propose to set string. For my project it's ok.

## What is the new behavior?
We can now use lang filter without any typescript error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

I'm not sure it's the good way to fix it but LGTM.
I can improve that if you are not ok with me.
