### PR TITLE
Remove default value of API.request data

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -199,7 +199,7 @@ export class API implements IAPI {
     method: RequestMethod,
     endpoint: string,
     params: object = {},
-    data: object = {},
+    data?: object,
     noProject: boolean = false,
     headers: { [key: string]: string } = {},
     skipParseToJSON: boolean = false

--- a/test/request.spec.ts
+++ b/test/request.spec.ts
@@ -74,7 +74,7 @@ describe("Request", () => {
 
       expect(client.api.xhr.request).to.have.been.calledWith({
         baseURL: "https://demo-api.getdirectus.com/testProject/",
-        data: {},
+        data: undefined,
         headers: { "X-Directus-Project": "testProject" },
         method: "get",
         params: {},
@@ -135,7 +135,7 @@ describe("Request", () => {
 
       expect(client.api.xhr.request).to.have.been.calledWith({
         baseURL: "https://demo-api.getdirectus.com/testProject/",
-        data: {},
+        data: undefined,
         headers: { "X-Directus-Project": "testProject" },
         method: "get",
         params: {
@@ -168,7 +168,7 @@ describe("Request", () => {
 
       expect(client.api.xhr.request).to.have.been.calledWith({
         baseURL: "https://demo-api.getdirectus.com/testProject/",
-        data: {},
+        data: undefined,
         headers: {
           Authorization: `Bearer ${client.config.token}`,
           "X-Directus-Project": "testProject",


### PR DESCRIPTION
This leaves up Axios decide on the best value to be used for it
This should make get request not contain any data, as expected

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] API docs have been updated (by executing `npm run documentation`)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #132 
API.request always sends a body, even in GET requests. This is invalid HTTP, so Cloudfront rejects those requests

## What is the new behavior?
API.request doesn't set any default value for request data, leaving up to Axios to handle it

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

The changes were tested using @directus/gatsby-source