### PR TITLE
#165 - change axios request timeout value to 1 hr so uploading a large file can succeed.

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -96,7 +96,7 @@ export class API implements IAPI {
   constructor(private config: IConfiguration) {
     const axiosOptions = {
       paramsSerializer: querify,
-      timeout: 10 * 60 * 1000, // 10 min
+      timeout: 60 * 60 * 1000, // 1 hour
       withCredentials: false,
     };
 


### PR DESCRIPTION
Change Axios request timeout value to 1 hr in API.ts, so uploading a large file (Giga Byte level) can succeed.
