### PR TITLE
Fix logout endpoint

### DIFF
--- a/src/Authentication.ts
+++ b/src/Authentication.ts
@@ -140,7 +140,7 @@ export class Authentication implements IAuthentication {
    * Logs the user out by "forgetting" the token, and clearing the refresh interval
    */
   public async logout(): Promise<ILogoutResponse> {
-    const response = await this.inject.request<ILogoutResponse>("post", "/auth/logout", {}, {}, true);
+    const response = await this.inject.request<ILogoutResponse>("post", "/auth/logout", {}, {}, false);
 
     this.config.token = undefined;
 

--- a/src/Authentication.ts
+++ b/src/Authentication.ts
@@ -140,7 +140,7 @@ export class Authentication implements IAuthentication {
    * Logs the user out by "forgetting" the token, and clearing the refresh interval
    */
   public async logout(): Promise<ILogoutResponse> {
-    const response = await this.inject.post<ILogoutResponse>("/auth/logout");
+    const response = await this.inject.request<ILogoutResponse>("post", "/auth/logout", {}, {}, false);
 
     this.config.token = undefined;
 

--- a/test/authentication.spec.ts
+++ b/test/authentication.spec.ts
@@ -129,6 +129,8 @@ describe("Authentication", () => {
     });
 
     it("Nullifies the token", async () => {
+      client.config.project = "testProject";
+
       await client.logout();
 
       expect(client.config.token).to.be.undefined;
@@ -348,6 +350,8 @@ describe("Authentication", () => {
       });
 
       it("Does not start the interval without the persist key", async () => {
+        client.config.project = "testProject";
+
         await client.logout();
         client.config.reset();
 

--- a/test/authentication.spec.ts
+++ b/test/authentication.spec.ts
@@ -111,6 +111,23 @@ describe("Authentication", () => {
   });
 
   describe("#logout()", () => {
+    it("Calls the right API logout endpoint", async () => {
+      client.config.project = "testProject";
+
+      await client.logout();
+
+      expect(client.api.xhr.request).to.have.been.calledWith({
+        baseURL: "https://demo-api.getdirectus.com/testProject/",
+        data: {},
+        headers: {
+          "X-Directus-Project": "testProject",
+        },
+        method: "post",
+        params: {},
+        url: "/auth/logout",
+      });
+    });
+
     it("Nullifies the token", async () => {
       await client.logout();
 


### PR DESCRIPTION
<!-- 
Hi there!

Thanks for opening a Pull Request! 

Please let us know what you changed and why, and make sure that:
* Tests for the changes have been added / updated
* Docs are updated (if needed)
-->

Hey! I had a look to fix #147 

- I flipped the boolean in the logout method, (line 143), it now uses the "project" value in the config object. It may error if the config is absent I guess, but I don't think there is a possibility of calling .login() without having a valid config of the SDK? I had a look a the api and I don't see any system calls using logout(), maybe with the token?
- I added a test to verify it calls the correct api endpoint.
- I added the config now required by logout() to other tests.

It passes all tests and it works on my machine with a external API (the request completes successfully instead of 401ing)

This is my first time working with testing so please let me know if I did anything wrong!
