### PR TITLE
✨ Add getAsset() and getAssetUrl() methods

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -5,7 +5,7 @@
 // General scheme types types
 import { ILoginCredentials, ILoginOptions } from "./schemes/auth/Login";
 import { BodyType } from "./schemes/http/Body";
-import { QueryParams as QueryParamsType } from "./schemes/http/Query";
+import { QueryParams as QueryParamsType, AssetQueryParams as AssetQueryParamsType } from "./schemes/http/Query";
 // Directus scheme types
 import { IField } from "./schemes/directus/Field";
 import { IRelation } from "./schemes/directus/Relation";
@@ -39,6 +39,7 @@ import { Configuration, IConfiguration, IConfigurationOptions } from "./Configur
 
 import { IServerInformationResponse } from "./schemes/response/ServerInformation";
 import { ISettingsResponse } from "./schemes/response/Setting";
+
 
 // TODO: Move to shared types, SDK is the wrong place for that
 type PrimaryKeyType = string | number;
@@ -393,6 +394,45 @@ export class SDK {
   }
 
   // #endregion fields
+
+  // #region assets
+
+  /**
+   * @see https://docs.directus.io/api/reference.html#assets
+   */
+  public getAssetUrl(privateHash: string, params?: AssetQueryParamsType): string {
+    const url = [
+      this.config.url.replace(/\/$/, ""),
+      this.config.project,
+      "assets",
+      privateHash
+    ].join("/");
+    const querystring = Object.entries(params as any[]).map(([prop, val]: [string, any]) => `${prop}=${val}`).join("&");
+    return querystring.length === 0 ? url : url + "?" + querystring;
+  }
+
+  /**
+   * @see https://docs.directus.io/api/reference.html#assets
+   */
+  public async getAsset(privateHash: string, params?: AssetQueryParamsType) {
+    const previousResponseType = this.api.xhr.defaults.responseType;
+
+    this.api.xhr.defaults.responseType = 'arraybuffer';
+    const response = this.api.request(
+      "get",
+      "/assets/" + privateHash,
+      params,
+      undefined,
+      false,
+      undefined,
+      true
+    );
+    this.api.xhr.defaults.responseType = previousResponseType;
+
+    return response;
+  }
+
+  // #endregion assets
 
   // #region files
 

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -33,6 +33,7 @@ import { IUserResponse, IUsersResponse } from "./schemes/response/User";
 // Utilities
 import { getCollectionItemPath } from "./utils/collection";
 import { isString } from "./utils/is";
+import {querify} from "./utils/qs";
 // Manager classes
 import { API, IAPI } from "./API";
 import { Configuration, IConfiguration, IConfigurationOptions } from "./Configuration";
@@ -401,14 +402,15 @@ export class SDK {
    * @see https://docs.directus.io/api/reference.html#assets
    */
   public getAssetUrl(privateHash: string, params?: AssetQueryParamsType): string {
+    const querystring = params ? querify(params) : "";
     const url = [
       this.config.url.replace(/\/$/, ""),
       this.config.project,
       "assets",
       privateHash
     ].join("/");
-    const querystring = Object.entries(params as any[]).map(([prop, val]: [string, any]) => `${prop}=${val}`).join("&");
-    return querystring.length === 0 ? url : url + "?" + querystring;
+
+    return querystring.length > 0 ? url + "?" + querystring : url;
   }
 
   /**
@@ -417,7 +419,7 @@ export class SDK {
   public async getAsset(privateHash: string, params?: AssetQueryParamsType) {
     const previousResponseType = this.api.xhr.defaults.responseType;
 
-    this.api.xhr.defaults.responseType = 'arraybuffer';
+    this.api.xhr.defaults.responseType = "arraybuffer";
     const response = this.api.request(
       "get",
       "/assets/" + privateHash,

--- a/src/schemes/http/Query.ts
+++ b/src/schemes/http/Query.ts
@@ -35,3 +35,20 @@ interface IQueryParameters {
  * @see https://docs.directus.io/api/reference.html#query-parameters
  */
 export type QueryParams = Partial<IQueryParameters>;
+
+
+/**
+ * @internal
+ */
+interface IAssetQueryParameters {
+  key: string;
+  w: number;
+  h: number;
+  f: 'crop'|'contain';
+  q: number;
+}
+
+/**
+ * @see https://docs.directus.io/api/reference.html#query-parameters
+ */
+export type AssetQueryParams = Partial<IAssetQueryParameters>;

--- a/src/schemes/http/Query.ts
+++ b/src/schemes/http/Query.ts
@@ -44,7 +44,7 @@ interface IAssetQueryParameters {
   key: string;
   w: number;
   h: number;
-  f: 'crop'|'contain';
+  f: string;
   q: number;
 }
 

--- a/test/methods/assets.spec.ts
+++ b/test/methods/assets.spec.ts
@@ -1,0 +1,115 @@
+import * as chai from "chai";
+import * as sinon from "sinon";
+import * as sinonChai from "sinon-chai";
+import SDK from "../../src/";
+
+import { mockAxiosResponse } from "../mock/response";
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+describe("Assets", () => {
+  let client: SDK;
+
+  beforeEach(() => {
+    client = new SDK({
+      token: "abcdef",
+      url: "https://demo-api.getdirectus.com",
+      project: "testProject",
+      mode: "jwt",
+    });
+  });
+
+  describe("#getAssetUrl()", () => {
+    it("Return an original's URL when only passed the private hash", async () => {
+      const url = client.getAssetUrl("xxxxxxxx-xxxxxxxx");
+
+      expect(url).to.equal(
+        "https://demo-api.getdirectus.com/testProject/assets/xxxxxxxx-xxxxxxxx"
+      );
+    });
+
+    it("Return an original's URL when passed an empty params object", async () => {
+      const url = client.getAssetUrl("xxxxxxxx-xxxxxxxx", {});
+
+      expect(url).to.equal(
+        "https://demo-api.getdirectus.com/testProject/assets/xxxxxxxx-xxxxxxxx"
+      );
+    });
+
+    it("Return a thumbnail's URL when passed a thumbnail key", async () => {
+      const url = client.getAssetUrl("xxxxxxxx-xxxxxxxx", {
+        key: "thumbnail"
+      });
+
+      expect(url).to.equal(
+        "https://demo-api.getdirectus.com/testProject/assets/xxxxxxxx-xxxxxxxx" +
+        "?key=thumbnail"
+      );
+    });
+
+    it("Return a thumbnail's URL when passed thumbnail specs", async () => {
+      const url = client.getAssetUrl("xxxxxxxx-xxxxxxxx", {
+        w: 100,
+        h: 75,
+        f: "crop",
+        q: 80,
+      });
+
+      expect(url).to.equal(
+        "https://demo-api.getdirectus.com/testProject/assets/xxxxxxxx-xxxxxxxx" +
+        "?w=100&h=75&f=crop&q=80"
+      );
+    });
+  });
+
+  describe("#getAsset()", () => {
+    beforeEach(() => {
+      const responseArrayBuffer = mockAxiosResponse<ArrayBuffer>(new ArrayBuffer(0));
+      sinon.stub(client.api.xhr, "request").resolves(responseArrayBuffer);
+    });
+
+    afterEach(() => {
+      (client.api.xhr.request as any).restore();
+    });
+
+    it("Return a thumbnail when passed a thumbnail key", async () => {
+      const params = {
+        key: "thumbnail"
+      };
+      await client.getAsset("xxxxxxxx-xxxxxxxx", params);
+
+      expect(client.api.xhr.request).to.have.been.calledWith(sinon.match({
+        baseURL: "https://demo-api.getdirectus.com/testProject/",
+        url: "/assets/xxxxxxxx-xxxxxxxx",
+        params: sinon.match(params),
+      }));
+    });
+
+    it("Return a thumbnail when passed thumbnail specs", async () => {
+      const params = {
+        w: 100,
+        h: 75,
+        f: "crop",
+        q: 80,
+      };
+      await client.getAsset("xxxxxxxx-xxxxxxxx", params);
+
+      expect(client.api.xhr.request).to.have.been.calledWith(sinon.match({
+        baseURL: "https://demo-api.getdirectus.com/testProject/",
+        url: "/assets/xxxxxxxx-xxxxxxxx",
+        params: sinon.match(params),
+      }));
+    });
+
+    it("Restores the axios responseType after running the query", async () => {
+      const previousResponseType = client.api.xhr.defaults.responseType;
+      const params = { key: "thumbnail" };
+
+      await client.getAsset("xxxxxxxx-xxxxxxxx", params);
+
+      expect(client.api.xhr.request).to.have.been.called;
+      expect(client.api.xhr.defaults.responseType).to.equal(previousResponseType);
+    });
+  });
+});


### PR DESCRIPTION
I added the `getAssetUrl()` & `getAsset()` methods to avoid having to build an asset URL manually.

  * `getAssetUrl()`: returns the URL of an asset (original or thumbnail)
     I chose to build the querystring without adding a dependency, but as a result, the code is quite messy
  * `getAsset()`: returns the asset directcly, as an ArrayBuffer
    As I found no way to pass the axios `responseType` parameter using the `API.request()` method, I changed the axios defaults before running the query and change it back afterwards

Feel free to ask for edit.

There are no tests nor documentation yet as I'm not sure you want to merge this. If you do, please tell me, I'll add the doc & tests.
