### PR TITLE
Add logical filter operator to typescript definition

### DIFF
--- a/src/schemes/http/Filter.ts
+++ b/src/schemes/http/Filter.ts
@@ -1,6 +1,6 @@
 /**
  * Defines all possible operator for filtering by query
- * @see https://docs.directus.io/api/reference.html#filtering
+ * @see https://docs.directus.io/api/query/filter.html
  */
 export type FilterOperator =
   | "="
@@ -31,4 +31,5 @@ export type FilterOperator =
   | "empty"
   | "nempty"
   | "all"
-  | "has";
+  | "has"
+  | "logical";


### PR DESCRIPTION
The `FilterOperator` doesn't include the `"logical"` key. So the following would not work:

```
interface Filter {
    filter: {
        [field: string]: { [operator in FilterOperator]?: any };
    }
}
function companyFilter(companyId: number): Filter {
    return { filter: { company: { null: '', logical: 'or', eq: companyId } } };
}
```
I also updated the link to the docs.