### PR TITLE
set url & project as optional parameters on login

### DIFF
--- a/src/schemes/auth/Login.ts
+++ b/src/schemes/auth/Login.ts
@@ -3,8 +3,8 @@ import { AuthModes } from "../../Authentication";
 export interface ILoginCredentials {
   email: string;
   password: string;
-  url: string;
-  project: string;
+  url?: string;
+  project?: string;
   persist?: boolean;
   otp?: string;
 }


### PR DESCRIPTION
Allows the "url" and "project" parameters to be undefined. If you have an already initialized SDK it's not needed to provide them, as it works already.

Passes test, open to adding some more if you guys have any ideas.

Fixes this kind of situation:
![image](https://user-images.githubusercontent.com/17851386/88081709-0e56a300-cb81-11ea-89f8-60665ef0d9cb.png)
![image](https://user-images.githubusercontent.com/17851386/88081763-28908100-cb81-11ea-96a7-6540e1f43f85.png)
